### PR TITLE
feat: add --no-io flag to disable async I/O tracking

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,6 +15,7 @@ function parseCliArgs(argv) {
     threshold: '50',
     interval: '100',
     'io-threshold': '500',
+    'no-io': false,
     json: false,
     watch: false,
     help: false,
@@ -33,6 +34,7 @@ function parseCliArgs(argv) {
   const boolMap = {
     '-j': 'json', '--json': 'json',
     '-w': 'watch', '--watch': 'watch',
+    '--no-io': 'no-io',
     '-h': 'help', '--help': 'help',
     '-v': 'version', '--version': 'version',
   };
@@ -93,6 +95,7 @@ function printUsage() {
     -t, --threshold <ms>     Event loop lag threshold in ms (default: 50)
     -i, --interval <ms>      Sampling interval in ms (default: 100)
     --io-threshold <ms>      Slow I/O threshold in ms (default: 500)
+    --no-io                  Disable async I/O tracking
     -j, --json               Output results as JSON
     -w, --watch              Continuous monitoring mode
     -h, --help               Show this help
@@ -121,6 +124,7 @@ async function main() {
     threshold: parseInt(values.threshold, 10),
     interval: parseInt(values.interval, 10),
     ioThreshold: parseInt(values['io-threshold'], 10),
+    noIO: values['no-io'],
     watch: values.watch,
     json: values.json,
   };

--- a/src/detective.js
+++ b/src/detective.js
@@ -427,7 +427,9 @@ class Detective extends EventEmitter {
     try {
       // Step 3: Start lag detection + async I/O tracking
       await this._startLagDetection();
-      await this._startAsyncIOTracking();
+      if (!this.config.noIO) {
+        await this._startAsyncIOTracking();
+      }
 
       // Step 4: Capture CPU profile
       const profile = await this._captureProfile(this.config.duration);
@@ -442,7 +444,9 @@ class Detective extends EventEmitter {
 
   async _watchMode() {
     await this._startLagDetection();
-    await this._startAsyncIOTracking();
+    if (!this.config.noIO) {
+      await this._startAsyncIOTracking();
+    }
 
     const runCycle = async () => {
       if (!this._running) return;


### PR DESCRIPTION
## Summary

Closes #11 — Add `--no-io` flag to disable I/O tracking.

## Motivation

The monkey-patching approach for I/O tracking (patching `http.request`, `dns.lookup`, `net.Socket.connect`) is more invasive than the lag detector or CPU profiler. Some users may want to opt out, especially in sensitive production environments.

## Changes

- New `--no-io` boolean CLI flag
- When set, `_startAsyncIOTracking()` is skipped entirely
- Lag detection and CPU profiling work normally
- Help text updated

## Usage

```bash
# Profile without I/O tracking
loop-detective 12345 --no-io

# Normal (I/O tracking enabled by default)
loop-detective 12345
```

## Testing

- Existing tests pass
- No new dependencies